### PR TITLE
Add aries to device names. CWM Recovery requires device name aries

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -19,7 +19,7 @@ include device/sony/shinano-common/BoardConfigCommon.mk
 #-include vendor/sony/z3c/BoardConfigVendor.mk
 
 # Assert
-TARGET_OTA_ASSERT_DEVICE := D5803,D5833,z3c
+TARGET_OTA_ASSERT_DEVICE := D5803,D5833,z3c,aries
 
 TARGET_SPECIFIC_HEADER_PATH += device/sony/z3c/include
 


### PR DESCRIPTION
CWM Recovery complains about the device name when flashing from the zip file.
